### PR TITLE
Fix: `sizes` Attribute Parsed Incorrectly for `img` Elements

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -10,6 +10,7 @@ var booleanish = types.booleanish
 var number = types.number
 var spaceSeparated = types.spaceSeparated
 var commaSeparated = types.commaSeparated
+var commaOrSpaceSeparated = types.commaOrSpaceSeparated
 
 module.exports = create({
   space: 'html',
@@ -128,7 +129,7 @@ module.exports = create({
     selected: boolean,
     shape: null,
     size: number,
-    sizes: spaceSeparated,
+    sizes: commaOrSpaceSeparated,
     slot: null,
     span: number,
     spellCheck: booleanish,

--- a/lib/html.js
+++ b/lib/html.js
@@ -10,7 +10,6 @@ var booleanish = types.booleanish
 var number = types.number
 var spaceSeparated = types.spaceSeparated
 var commaSeparated = types.commaSeparated
-var commaOrSpaceSeparated = types.commaOrSpaceSeparated
 
 module.exports = create({
   space: 'html',
@@ -129,7 +128,7 @@ module.exports = create({
     selected: boolean,
     shape: null,
     size: number,
-    sizes: commaOrSpaceSeparated,
+    sizes: null,
     slot: null,
     span: number,
     spellCheck: booleanish,


### PR DESCRIPTION
In the `properties` map for the HTML space, `sizes` is marked as `spaceSeparated` ([html.js#L131](https://github.com/wooorm/property-information/blob/master/lib/html.js#L131))

According to the W3 spec, that's valid for `link` elements

> If specified, the attribute must have a value that is an unordered set of unique space-separated tokens which are ASCII case-insensitive.
> [W3 HTML 5.2: 4.2.4](https://www.w3.org/TR/html52/document-metadata.html#element-attrdef-link-sizes)

But for `img` elements, the tokens are supposed to be comma separated

> A valid source size list is a string that matches the following grammar:
> `<source-size-list> = <source-size># [ , <source-size-value> ]? | <source-size-value>`
> [W3 HTML 5.2: 4.7.5 valid-source-size-list](https://www.w3.org/TR/html52/semantics-embedded-content.html#valid-source-size-list)

> When asked to parse a sizes attribute from an element, parse a comma-separated list of component values from the value of the element’s sizes attribute (or the empty string, if the attribute is absent)
> [W3 HTML 5.2: 4.7.5 parse-a-sizes-attribute](https://www.w3.org/TR/html52/semantics-embedded-content.html#parse-a-sizes-attribute)

This change sets the `sizes` property to be `commaOrSpaceSeparated` (assuming this is the correct intent for the flag)