### PR TITLE
Make `hidden` attribute `overloadedBoolean`

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -70,7 +70,7 @@ export const html = create({
     formTarget: null,
     headers: spaceSeparated,
     height: number,
-    hidden: boolean,
+    hidden: overloadedBoolean,
     high: number,
     href: null,
     hrefLang: null,


### PR DESCRIPTION
Current PR change the value of the `hidden` attribute from `boolean` to `overloadedBoolean` as `hidden` attribute can be more than a boolean. Specifically, if it has `until-found` value it can change the behavior of the component in a dramatic way. 

See the specification for `hidden`: https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute